### PR TITLE
chore(ci): добавить запуск сбора метрик threads

### DIFF
--- a/.github/workflows/threads-metrics.yml
+++ b/.github/workflows/threads-metrics.yml
@@ -1,0 +1,33 @@
+name: Threads Metrics
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: threads-metrics
+  cancel-in-progress: true
+
+jobs:
+  run-metrics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      THREADS_METRICS_API_TOKEN: ${{ secrets.THREADS_METRICS_API_TOKEN }}
+      THREADS_METRICS_DB_URL: ${{ secrets.THREADS_METRICS_DB_URL }}
+      THREADS_METRICS_HEARTBEAT_INTERVAL: ${{ secrets.THREADS_METRICS_HEARTBEAT_INTERVAL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run metrics collection
+        run: python -m threads_metrics.main --heartbeat


### PR DESCRIPTION
## Summary
- добавить планировщик GitHub Actions для регулярного и ручного запуска сборщика метрик
- настроить переменные окружения, таймаут, блокировку параллельных запусков и передачу heartbeat-параметров скрипту

## Testing
- не запускались

------
https://chatgpt.com/codex/tasks/task_e_68d2585ce0d4832d996115dc49e573fc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a scheduled CI workflow that runs periodically and can also be triggered manually.
  - Sets up the runtime environment, installs dependencies, and executes a maintenance task within a defined timeout.
  - Improves reliability of background operations and monitoring.
  - No user-facing changes or impact to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->