### PR TITLE
chore: прописать PYTHONPATH для метрик

### DIFF
--- a/.github/workflows/threads-metrics.yml
+++ b/.github/workflows/threads-metrics.yml
@@ -17,6 +17,7 @@ jobs:
       THREADS_METRICS_API_TOKEN: ${{ secrets.THREADS_METRICS_API_TOKEN }}
       THREADS_METRICS_DB_URL: ${{ secrets.THREADS_METRICS_DB_URL }}
       THREADS_METRICS_HEARTBEAT_INTERVAL: ${{ secrets.THREADS_METRICS_HEARTBEAT_INTERVAL }}
+      PYTHONPATH: src
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+export PYTHONPATH=src
 ```
 
 ## Конфигурация


### PR DESCRIPTION
## Summary
- добавить PYTHONPATH=src в workflow threads-metrics
- дописать инструкцию по экспорту PYTHONPATH в README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2706ae10c832d811e2b1c330610f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include exporting PYTHONPATH=src, ensuring imports resolve correctly during local development and testing.

* **Chores**
  * Adjusted CI workflow to set PYTHONPATH for the metrics job, improving import resolution and reducing execution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->