### PR TITLE
fix: нормализовать permalink threads

### DIFF
--- a/src/threads_metrics/threads_client.py
+++ b/src/threads_metrics/threads_client.py
@@ -128,8 +128,21 @@ class ThreadsClient:
 
     @staticmethod
     def _sanitize_permalink(permalink: str) -> str:
+        prefixes = (
+            "https://www.threads.com/",
+            "https://www.threads.net/",
+        )
+
+        for prefix in prefixes:
+            if permalink.startswith(prefix):
+                permalink = permalink[len(prefix) :]
+                if not permalink.startswith("/"):
+                    permalink = f"/{permalink}"
+                break
+
         if "?" in permalink:
-            return permalink.split("?", maxsplit=1)[0]
+            permalink = permalink.split("?", maxsplit=1)[0]
+
         return permalink
 
     @staticmethod

--- a/tests/test_threads_client.py
+++ b/tests/test_threads_client.py
@@ -1,0 +1,28 @@
+import pytest
+
+from src.threads_metrics.threads_client import ThreadsClient
+
+
+@pytest.mark.parametrize(
+    "permalink, expected",
+    [
+        (
+            "https://www.threads.net/@example/post/123?utm_source=test",
+            "/@example/post/123",
+        ),
+        (
+            "https://www.threads.com/@example/post/456",
+            "/@example/post/456",
+        ),
+        (
+            "/@example/post/789?foo=bar",
+            "/@example/post/789",
+        ),
+        (
+            "https://external.site/@example/post/000?utm_source=test",
+            "https://external.site/@example/post/000",
+        ),
+    ],
+)
+def test_sanitize_permalink(permalink: str, expected: str) -> None:
+    assert ThreadsClient._sanitize_permalink(permalink) == expected


### PR DESCRIPTION
## Цель изменения
Привести permalink постов Threads к относительному виду и гарантировать отсутствие доменного префикса, чтобы downstream-потребители работали с единым форматом ссылок.

## Влияние на производительность и сеть
Изменения затрагивают только постобработку ответов API и юнит-тесты, сетевые запросы и их количество остаются прежними.

## Затронутые модули
- `src/threads_metrics/threads_client.py`
- `tests/test_threads_client.py`

## Ретраи и обработка ошибок
Существующая логика ретраев в `ThreadsClient._request` не менялась и продолжает использовать `tenacity` с экспоненциальным бэкоффом.

------
https://chatgpt.com/codex/tasks/task_e_68d2706e251c832d9a8c51dc865cd9a8