### PR TITLE
feat: поддержать insights Threads и TTL кеша

### DIFF
--- a/src/threads_metrics/aggregation.py
+++ b/src/threads_metrics/aggregation.py
@@ -1,0 +1,41 @@
+"""Функции агрегации метрик постов."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping
+
+
+def aggregate_posts(
+    posts: List[Dict[str, Any]],
+    insights: Mapping[str, Dict[str, int]],
+) -> List[Dict[str, Any]]:
+    """Агрегирует постовые данные и метрики Insights."""
+
+    aggregated: List[Dict[str, Any]] = []
+    for post in posts:
+        raw_post_id = post.get("id")
+        if not raw_post_id:
+            continue
+        post_id = str(raw_post_id)
+        insight = insights.get(post_id, {})
+        has_insight = post_id in insights
+        aggregated.append(
+            {
+                "account_name": post.get("account_name"),
+                "post_id": post_id,
+                "permalink": post.get("permalink"),
+                "text": post.get("text"),
+                "like_count": post.get("like_count", 0),
+                "repost_count": post.get("repost_count", 0),
+                "reply_count": post.get("reply_count", 0),
+                "views": insight.get("views") if has_insight else None,
+                "likes": insight.get("likes", post.get("like_count", 0)),
+                "replies": insight.get("replies", post.get("reply_count", 0)),
+                "reposts": insight.get("reposts", post.get("repost_count", 0)),
+                "quotes": insight.get("quotes") if has_insight else None,
+                "shares": insight.get("shares") if has_insight else None,
+            }
+        )
+    return aggregated
+
+
+__all__ = ["aggregate_posts"]

--- a/src/threads_metrics/google_sheets.py
+++ b/src/threads_metrics/google_sheets.py
@@ -98,7 +98,9 @@ class GoogleSheetsClient:
 
     def _merge_existing(self, existing_df: pd.DataFrame, new_df: pd.DataFrame) -> pd.DataFrame:
         timestamp_column = "updated_at"
-        key_columns = [col for col in new_df.columns if col not in {timestamp_column}]
+        key_columns = [col for col in ("account_name", "post_id") if col in new_df.columns]
+        if not key_columns:
+            key_columns = [col for col in new_df.columns if col not in {timestamp_column}]
         if not key_columns:
             return new_df
 

--- a/src/threads_metrics/state_store.py
+++ b/src/threads_metrics/state_store.py
@@ -16,6 +16,7 @@ class AppState:
 
     cursors: Dict[str, str] = field(default_factory=dict)
     last_metrics_write: Optional[str] = None
+    post_metrics_updated_at: Dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Optional[str]]:
         """Преобразует состояние к словарю."""
@@ -23,6 +24,7 @@ class AppState:
         return {
             "cursors": self.cursors,
             "last_metrics_write": self.last_metrics_write,
+            "post_metrics_updated_at": self.post_metrics_updated_at,
         }
 
     @classmethod
@@ -31,7 +33,12 @@ class AppState:
 
         cursors = data.get("cursors") or {}
         last_metrics_write = data.get("last_metrics_write")
-        return cls(cursors=dict(cursors), last_metrics_write=last_metrics_write)
+        post_metrics_updated_at = data.get("post_metrics_updated_at") or {}
+        return cls(
+            cursors=dict(cursors),
+            last_metrics_write=last_metrics_write,
+            post_metrics_updated_at=dict(post_metrics_updated_at),
+        )
 
 
 class StateStore:
@@ -66,6 +73,42 @@ class StateStore:
         self._state.last_metrics_write = now
         self._save()
 
+    def get_post_metrics_timestamp(self, post_id: str) -> Optional[dt.datetime]:
+        """Возвращает время последнего обновления метрик поста."""
+
+        timestamp = self._state.post_metrics_updated_at.get(post_id)
+        if not timestamp:
+            return None
+        return dt.datetime.fromisoformat(timestamp)
+
+    def should_refresh_post_metrics(
+        self, post_id: str, ttl_minutes: int, *, now: Optional[dt.datetime] = None
+    ) -> bool:
+        """Определяет, нужно ли обновлять метрики поста."""
+
+        now_dt = now or dt.datetime.now(TIMEZONE)
+        last_update = self.get_post_metrics_timestamp(post_id)
+        if not last_update:
+            return True
+        return now_dt - last_update >= dt.timedelta(minutes=ttl_minutes)
+
+    def update_post_metrics_timestamp(
+        self, post_id: str, timestamp: Optional[dt.datetime] = None
+    ) -> None:
+        """Сохраняет время обновления метрик поста."""
+
+        moment = timestamp or dt.datetime.now(TIMEZONE)
+        self._state.post_metrics_updated_at[post_id] = moment.isoformat()
+        self._save()
+
+    def update_post_metrics_many(self, timestamps: Dict[str, dt.datetime]) -> None:
+        """Массово обновляет отметки времени метрик постов."""
+
+        for post_id, moment in timestamps.items():
+            self._state.post_metrics_updated_at[post_id] = moment.isoformat()
+        if timestamps:
+            self._save()
+
     def _load(self) -> AppState:
         if not self._path.exists():
             return AppState()
@@ -80,4 +123,4 @@ class StateStore:
         self._path.write_text(json.dumps(self._state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-__all__ = ["StateStore", "AppState"]
+__all__ = ["StateStore", "AppState", "TIMEZONE"]

--- a/src/threads_metrics/threads_client.py
+++ b/src/threads_metrics/threads_client.py
@@ -126,6 +126,36 @@ class ThreadsClient:
                 return response.json()
         raise ThreadsAPIError("Не удалось получить ответ от Threads API")
 
+    async def fetch_post_insights(self, access_token: str, post_id: str) -> Dict[str, int]:
+        """Возвращает метрики Insights для указанного поста."""
+
+        metrics_map = {
+            "view_count": "views",
+            "like_count": "likes",
+            "reply_count": "replies",
+            "repost_count": "reposts",
+            "quote_count": "quotes",
+            "share_count": "shares",
+        }
+        params = {"metric": ",".join(metrics_map.keys())}
+        async with self._semaphore:
+            data = await self._request(f"/{post_id}/insights", access_token=access_token, params=params)
+
+        insights: Dict[str, int] = {value: 0 for value in metrics_map.values()}
+        for item in data.get("data", []):
+            metric_name = metrics_map.get(item.get("name", ""))
+            if not metric_name:
+                continue
+            values = item.get("values") or []
+            if not values:
+                continue
+            value = values[0].get("value")
+            try:
+                insights[metric_name] = int(value)
+            except (TypeError, ValueError):
+                continue
+        return insights
+
     @staticmethod
     def _sanitize_permalink(permalink: str) -> str:
         if "?" in permalink:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,58 @@
+"""Тесты для функций основного модуля."""
+from __future__ import annotations
+
+from threads_metrics.aggregation import aggregate_posts
+
+
+def test_aggregate_posts_merges_insights() -> None:
+    """Проверяет объединение постов с данными Insights."""
+
+    posts = [
+        {
+            "id": "1",
+            "account_name": "acc",
+            "permalink": "https://example.com/1",
+            "text": "post 1",
+            "like_count": 10,
+            "reply_count": 2,
+            "repost_count": 3,
+        },
+        {
+            "id": "2",
+            "account_name": "acc",
+            "permalink": "https://example.com/2",
+            "text": "post 2",
+            "like_count": 5,
+            "reply_count": 1,
+            "repost_count": 0,
+        },
+    ]
+    insights = {
+        "1": {
+            "views": 120,
+            "likes": 15,
+            "replies": 4,
+            "reposts": 6,
+            "quotes": 2,
+            "shares": 3,
+        }
+    }
+
+    aggregated = aggregate_posts(posts, insights)
+
+    first = next(item for item in aggregated if item["post_id"] == "1")
+    second = next(item for item in aggregated if item["post_id"] == "2")
+
+    assert first["views"] == 120
+    assert first["likes"] == 15
+    assert first["replies"] == 4
+    assert first["reposts"] == 6
+    assert first["quotes"] == 2
+    assert first["shares"] == 3
+
+    assert second["views"] is None
+    assert second["likes"] == 5
+    assert second["replies"] == 1
+    assert second["reposts"] == 0
+    assert second["quotes"] is None
+    assert second["shares"] is None

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,40 @@
+"""Тесты для хранилища состояния."""
+from __future__ import annotations
+
+import datetime as dt
+
+from threads_metrics.state_store import StateStore, TIMEZONE
+
+
+def test_state_store_post_metrics_ttl(tmp_path) -> None:
+    """Проверяет применение TTL при обновлении метрик постов."""
+
+    state_file = tmp_path / "state.json"
+    store = StateStore(state_file)
+
+    assert store.should_refresh_post_metrics("123", ttl_minutes=60)
+
+    now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=TIMEZONE)
+    store.update_post_metrics_timestamp("123", timestamp=now)
+
+    assert not store.should_refresh_post_metrics("123", ttl_minutes=120, now=now + dt.timedelta(minutes=30))
+    assert store.should_refresh_post_metrics("123", ttl_minutes=60, now=now + dt.timedelta(minutes=90))
+
+    # Пересоздаём стор, чтобы убедиться в сохранении состояния.
+    store_reloaded = StateStore(state_file)
+    assert not store_reloaded.should_refresh_post_metrics(
+        "123", ttl_minutes=120, now=now + dt.timedelta(minutes=30)
+    )
+
+
+def test_state_store_bulk_update(tmp_path) -> None:
+    """Проверяет массовое обновление меток времени."""
+
+    state_file = tmp_path / "state.json"
+    store = StateStore(state_file)
+
+    timestamp = dt.datetime(2024, 1, 1, 15, 0, tzinfo=TIMEZONE)
+    store.update_post_metrics_many({"1": timestamp, "2": timestamp + dt.timedelta(minutes=5)})
+
+    assert not store.should_refresh_post_metrics("1", ttl_minutes=120, now=timestamp + dt.timedelta(minutes=30))
+    assert store.should_refresh_post_metrics("2", ttl_minutes=1, now=timestamp + dt.timedelta(minutes=10))


### PR DESCRIPTION
## Цель
Добавить сбор метрик Threads Insights с учётом ограничений TTL и сохранить единый поток записи данных в Google Sheets.

## Влияние на производительность и сеть
- Дополнительные запросы к `/{post_id}/insights` выполняются параллельно с ограничением по текущему семафору клиента и пропускаются для постов моложе TTL.
- Таймауты и политика ретраев наследуются от существующего клиента `ThreadsClient` (до 5 попыток с экспоненциальным бэкоффом).

## Затронутые модули
- `threads_client` — добавлен метод получения Insights.
- `main` — параллельный сбор Insights, объединение с постами, использование TTL из `StateStore`.
- `state_store` и `google_sheets` — хранение отметок обновления по постам и корректная агрегация при записи.
- `tests` — новые проверки агрегации и TTL.

## Ретраи и обработка ошибок
- Ретраи HTTP-запросов к Insights используют существующую логику `AsyncRetrying` c экспоненциальным бэкоффом и обработкой `httpx.HTTPError`.

------
https://chatgpt.com/codex/tasks/task_e_68d2706fa41c832da7116147b0a536ef