### PR TITLE
fix(ci): прокинуть секрет сервисного аккаунта

### DIFF
--- a/.github/workflows/threads-metrics.yml
+++ b/.github/workflows/threads-metrics.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 35
     env:
       ID_GOOGLE_TABLE: ${{ secrets.ID_GOOGLE_TABLE }}
+      GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
       THREADS_METRICS_API_TOKEN: ${{ secrets.THREADS_METRICS_API_TOKEN }}
       THREADS_METRICS_DB_URL: ${{ secrets.THREADS_METRICS_DB_URL }}
       URL_GAS_RAZVERTIVANIA: ${{ secrets.URL_GAS_RAZVERTIVANIA }}


### PR DESCRIPTION
## Summary
- добавить проброс секрета GOOGLE_SERVICE_ACCOUNT_JSON в workflow метрик

## Testing
- не запускались

------
https://chatgpt.com/codex/tasks/task_e_68d2a543b16c832da94100dbfd0ec0e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the metrics collection workflow to include a new environment variable for Google service account credentials, improving integration with external reporting services.
  * Enhances reliability of automated metrics processing in CI without impacting application functionality.
  * No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->