### PR TITLE
docs: уточнить загрузку переменных окружения

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,24 @@ export PYTHONPATH=src
 - `THREADS_STATE_FILE` — путь к файлу состояния.
 - `THREADS_METRICS_TTL_MIN` — TTL метрик в минутах.
 
+Приложение не читает `.env` автоматически — переменные должны попасть в окружение перед запуском. В POSIX-оболочках можно сделать так:
+
+```bash
+set -a
+source .env
+set +a
+python -m threads_metrics.main run
+```
+
+На Windows можно воспользоваться `python-dotenv` (`python -m dotenv run -- python -m threads_metrics.main run`) либо задать переменные вручную через `set KEY=VALUE` перед запуском.
+
 ## Запуск
 
 ```bash
 python -m threads_metrics.main run
 ```
+
+Перед выполнением убедитесь, что переменные окружения загружены согласно разделу «Конфигурация».
 
 Команда запуска организует асинхронный сбор постов из Threads по токенам с листа `accounts_threads`,
 агрегирует метрики и записывает их на лист `Data_Po_kagdomy_posty`. Прогресс обработки хранится в


### PR DESCRIPTION
## Цель изменения
- пояснить, что приложение не подхватывает `.env` автоматически;
- добавить инструкции по загрузке переменных окружения для POSIX и Windows.

## Влияние на производительность и сеть
- отсутствует.

## Затронутые модули
- `README.md` (документация по конфигурации и запуску).

## Ретраи и обработка ошибок
- не применимо.


------
https://chatgpt.com/codex/tasks/task_e_68d2aa7a16f8832db106694b3fe68e04