### PR TITLE
fix: корректно задавать контекст логов

### DIFF
--- a/src/threads_metrics/main.py
+++ b/src/threads_metrics/main.py
@@ -23,18 +23,20 @@ TIMEOUT_SECONDS = 35 * 60
 def setup_logging() -> None:
     """Настраивает вывод логов в формате JSON."""
 
-    class _ContextFilter(logging.Filter):
-        def filter(self, record: logging.LogRecord) -> bool:
-            if not hasattr(record, "context"):
-                record.context = json.dumps({})
-            return True
+    previous_factory = logging.getLogRecordFactory()
 
+    def record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = previous_factory(*args, **kwargs)
+        if not hasattr(record, "context"):
+            record.context = json.dumps({})
+        return record
+
+    logging.setLogRecordFactory(record_factory)
     logging.basicConfig(
         level=logging.INFO,
         format='{"ts":"%(asctime)sZ","level":"%(levelname)s","msg":"%(message)s","context":%(context)s}',
         datefmt="%Y-%m-%dT%H:%M:%S",
     )
-    logging.getLogger().addFilter(_ContextFilter())
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,32 @@
+"""Тесты для настройки логирования."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from threads_metrics.main import setup_logging
+
+
+def test_setup_logging_sets_default_context() -> None:
+    """Проверяет, что фабрика логов добавляет контекст по умолчанию."""
+
+    original_factory = logging.getLogRecordFactory()
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+
+    logger = logging.getLogger("threads.test.logger")
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(logging.Formatter("%(context)s"))
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    try:
+        setup_logging()
+        logger.info("test message without extra")
+        handler.flush()
+        assert handler.stream.getvalue().strip() == "{}"
+    finally:
+        logging.setLogRecordFactory(original_factory)
+        logger.removeHandler(handler)
+        logging.root.handlers.clear()


### PR DESCRIPTION
## Цель
- гарантировать наличие поля `context` в логах даже при отключённой передаче сообщений к корню
- покрыть настройку логирования тестом

## Влияние на производительность и сеть
- отсутствует

## Затронутые модули
- src/threads_metrics/main.py
- tests/test_logging.py

## Логика ретраев и обработка ошибок
- без изменений

------
https://chatgpt.com/codex/tasks/task_e_68d2e0ded980832d876cfa0647382606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined logging to ensure a default context is attached to every log entry, maintaining the existing JSON-formatted output.
  - Improves consistency of log context across all scenarios without changing public APIs or user workflows.

- **Chores**
  - Removed legacy logging components no longer needed after the update.

- **Notes**
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->