### PR TITLE
fix: заменить фабрику записей на форматтер для контекста логов

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,30 +3,69 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
+from contextlib import contextmanager
+from typing import Any, Iterator
 
 from threads_metrics.main import setup_logging
 
 
-def test_setup_logging_sets_default_context() -> None:
-    """Проверяет, что фабрика логов добавляет контекст по умолчанию."""
+def _reset_logging() -> None:
+    """Очищает обработчики корневого логгера."""
 
-    original_factory = logging.getLogRecordFactory()
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
 
-    logger = logging.getLogger("threads.test.logger")
-    handler = logging.StreamHandler(io.StringIO())
-    handler.setFormatter(logging.Formatter("%(context)s"))
-    logger.addHandler(handler)
-    logger.propagate = False
 
+@contextmanager
+def _capture_root_stream() -> Iterator[tuple[logging.Handler, io.StringIO]]:
+    """Подменяет поток первого обработчика корневого логгера."""
+
+    if not logging.root.handlers:
+        raise AssertionError("Ожидался хотя бы один обработчик логирования")
+    handler = logging.root.handlers[0]
+    stream = io.StringIO()
+    original_stream = handler.stream
+    handler.setStream(stream)
+    try:
+        yield handler, stream
+    finally:
+        handler.setStream(original_stream)
+
+
+def test_setup_logging_sets_default_context() -> None:
+    """Проверяет, что форматтер добавляет контекст по умолчанию."""
+
+    payload: dict[str, Any] | None = None
+    _reset_logging()
     try:
         setup_logging()
-        logger.info("test message without extra")
-        handler.flush()
-        assert handler.stream.getvalue().strip() == "{}"
+        with _capture_root_stream() as (handler, stream):
+            logging.info("test message without extra")
+            handler.flush()
+            payload = json.loads(stream.getvalue())
     finally:
-        logging.setLogRecordFactory(original_factory)
-        logger.removeHandler(handler)
-        logging.root.handlers.clear()
+        _reset_logging()
+    assert payload is not None
+    assert payload["msg"] == "test message without extra"
+    assert payload["context"] == {}
+
+
+def test_setup_logging_with_custom_context() -> None:
+    """Проверяет корректное форматирование пользовательского контекста."""
+
+    payload: dict[str, Any] | None = None
+    _reset_logging()
+    try:
+        setup_logging()
+        custom_context = {"foo": "bar"}
+        with _capture_root_stream() as (handler, stream):
+            logging.info("test message", extra={"context": json.dumps(custom_context)})
+            handler.flush()
+            payload = json.loads(stream.getvalue())
+    finally:
+        _reset_logging()
+    assert payload is not None
+    assert payload["msg"] == "test message"
+    assert payload["context"] == custom_context


### PR DESCRIPTION
## Цель изменения
Переписать настройку логирования, убрав использование `logging.setLogRecordFactory`, и добавить покрывающие тесты для нового форматтера контекста.

## Влияние на производительность и сеть
Изменений нет: обработка логов выполняется локально, сетевые вызовы не затронуты.

## Затронутые модули
- `src/threads_metrics/main.py`
- `tests/test_logging.py`

## Обработка ошибок и ретраи
Логика ретраев и обработки ошибок не менялась.

## Тестирование
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2f358b790832d91e723e5a8bb2754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked logging to use a dedicated formatter and handler while preserving JSON output fields (ts, level, msg, context).
* **Bug Fixes**
  * Ensures every log entry consistently includes a context field for uniform JSON structure.
* **Chores**
  * Standardized logging configuration for predictable behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->