### PR TITLE
fix: игнорировать ошибки получения инсайтов

### DIFF
--- a/tests/test_collect_insights.py
+++ b/tests/test_collect_insights.py
@@ -1,0 +1,71 @@
+"""Тесты для сбора инсайтов по постам."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+import httpx
+import pytest
+
+from threads_metrics.main import collect_insights
+
+
+@dataclass
+class DummyStateStore:
+    """Простая заглушка для проверки обновления метрик."""
+
+    refresh_calls: List[str] = field(default_factory=list)
+    updates: List[Dict[str, object]] = field(default_factory=list)
+
+    def should_refresh_post_metrics(self, post_id: str, ttl_minutes: int) -> bool:
+        self.refresh_calls.append(post_id)
+        return True
+
+    def update_post_metrics_many(self, timestamps: Dict[str, object]) -> None:
+        self.updates.append(dict(timestamps))
+
+
+class DummyClient:
+    """Клиент Threads, имитирующий ошибку для одного поста."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, str]] = []
+
+    async def fetch_post_insights(self, token: str, post_id: str) -> Dict[str, int]:
+        self.calls.append({"token": token, "post_id": post_id})
+        if post_id == "1":
+            request = httpx.Request("GET", "https://example.com/1")
+            response = httpx.Response(500, request=request)
+            raise httpx.HTTPStatusError("boom", request=request, response=response)
+        return {"views": 100, "likes": 5}
+
+
+def test_collect_insights_skips_failed_posts(caplog: pytest.LogCaptureFixture) -> None:
+    """Проверяет, что ошибки клиента не прерывают сбор инсайтов."""
+
+    posts = [
+        {"id": "1", "account_name": "acc1"},
+        {"id": "2", "account_name": "acc2"},
+    ]
+    tokens = {"acc1": "token1", "acc2": "token2"}
+    client = DummyClient()
+    state_store = DummyStateStore()
+
+    with caplog.at_level(logging.ERROR):
+        insights = asyncio.run(
+            collect_insights(posts, tokens, client, state_store, ttl_minutes=60)
+        )
+
+    assert "1" not in insights
+    assert insights["2"] == {"views": 100, "likes": 5}
+
+    assert state_store.updates
+    assert set(state_store.updates[0].keys()) == {"2"}
+
+    error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert error_records
+    contexts = [json.loads(record.context) for record in error_records]
+    assert any(context.get("post_id") == "1" for context in contexts)


### PR DESCRIPTION
## Цель
- обрабатывать ошибки Threads API при сборе инсайтов, чтобы сервис продолжал обновление метрик по остальным постам

## Влияние на производительность и сеть
- дополнительных сетевых запросов не добавлено; текущие таймауты и параллелизм не изменились

## Затронутые модули
- src/threads_metrics/main.py
- tests/test_collect_insights.py

## Обработка ошибок и ретраи
- вызов `fetch_post_insights` заключён в `try/except`, ошибки логируются с контекстом, проблемные посты пропускаются, а стор обновляется только по успешным ответам

## Тесты
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2fbf0975c832d92fa90de30426183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of post insights collection: failures for individual posts no longer block the entire update.
  - Ensures partial updates proceed, applying metrics for successful posts while skipping failed ones.
  - Prevents unnecessary updates when no valid data is available, reducing noise and potential inconsistencies.
  - Enhanced robustness leads to more consistent and up-to-date metrics in the dashboard, even under intermittent errors.
  - Maintains performance of parallel fetching while handling errors gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->