### PR TITLE
fix: завершать повторный запуск при активной блокировке

### DIFF
--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 
 from threads_metrics.state_store import StateStore, TIMEZONE
 
@@ -38,3 +39,34 @@ def test_state_store_bulk_update(tmp_path) -> None:
 
     assert not store.should_refresh_post_metrics("1", ttl_minutes=120, now=timestamp + dt.timedelta(minutes=30))
     assert store.should_refresh_post_metrics("2", ttl_minutes=1, now=timestamp + dt.timedelta(minutes=10))
+
+
+def test_state_store_run_lock(tmp_path) -> None:
+    """Проверяет установку и освобождение блокировки запуска."""
+
+    state_file = tmp_path / "state.json"
+    store = StateStore(state_file)
+
+    max_age = dt.timedelta(minutes=10)
+    assert store.try_acquire_run_lock(max_age=max_age)
+    assert not store.try_acquire_run_lock(max_age=max_age)
+
+    store.release_run_lock()
+    assert store.try_acquire_run_lock(max_age=max_age)
+
+
+def test_state_store_run_lock_expired(tmp_path) -> None:
+    """Проверяет снятие протухшей блокировки запуска."""
+
+    state_file = tmp_path / "state.json"
+    expired_state = {
+        "cursors": {},
+        "last_metrics_write": None,
+        "post_metrics_updated_at": {},
+        "run_started_at": (dt.datetime.now(TIMEZONE) - dt.timedelta(hours=1)).isoformat(),
+    }
+    state_file.write_text(json.dumps(expired_state), encoding="utf-8")
+
+    store = StateStore(state_file)
+
+    assert store.try_acquire_run_lock(max_age=dt.timedelta(minutes=10))


### PR DESCRIPTION
## Описание
- добавлена файловая блокировка запуска через `StateStore`, предотвращающая параллельные выполнения
- сервис завершает новый запуск, если предыдущий ещё выполняется, и освобождает блокировку по окончании работы
- покрытие логики блокировки юнит-тестами

## Влияние на производительность и сеть
- без изменений

## Затронутые модули
- `src/threads_metrics/main.py`
- `src/threads_metrics/state_store.py`
- `tests/test_state_store.py`

## Обработка ошибок и ретраи
- блокировка считается протухшей по истечении таймаута выполнения и снимается автоматически

## Тестирование
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3969efe24832d9f4a9c9ddf872d60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents overlapping metrics runs to avoid race conditions, duplicate processing, and partial writes.
  * Ensures the run is safely finalized even if errors occur, reducing the chance of stuck or repeated jobs.
  * Skips work when metrics are already up to date for more efficient operation.

* **Chores**
  * Improves structured logging to make run status and outcomes clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->