### PR TITLE
fix: синхронизировать счётчики метрик с инсайтами

### DIFF
--- a/src/threads_metrics/aggregation.py
+++ b/src/threads_metrics/aggregation.py
@@ -18,19 +18,43 @@ def aggregate_posts(
         post_id = str(raw_post_id)
         insight = insights.get(post_id, {})
         has_insight = post_id in insights
+
+        post_like_count = post.get("like_count")
+        if post_like_count is None:
+            post_like_count = 0
+        post_reply_count = post.get("reply_count")
+        if post_reply_count is None:
+            post_reply_count = 0
+        post_repost_count = post.get("repost_count")
+        if post_repost_count is None:
+            post_repost_count = 0
+
+        like_value = (
+            insight.get("likes", post_like_count) if has_insight else post_like_count
+        )
+        reply_value = (
+            insight.get("replies", post_reply_count)
+            if has_insight
+            else post_reply_count
+        )
+        repost_value = (
+            insight.get("reposts", post_repost_count)
+            if has_insight
+            else post_repost_count
+        )
         aggregated.append(
             {
                 "account_name": post.get("account_name"),
                 "post_id": post_id,
                 "permalink": post.get("permalink"),
                 "text": post.get("text"),
-                "like_count": post.get("like_count", 0),
-                "repost_count": post.get("repost_count", 0),
-                "reply_count": post.get("reply_count", 0),
+                "like_count": like_value,
+                "repost_count": repost_value,
+                "reply_count": reply_value,
                 "views": insight.get("views") if has_insight else None,
-                "likes": insight.get("likes", post.get("like_count", 0)),
-                "replies": insight.get("replies", post.get("reply_count", 0)),
-                "reposts": insight.get("reposts", post.get("repost_count", 0)),
+                "likes": like_value,
+                "replies": reply_value,
+                "reposts": repost_value,
                 "quotes": insight.get("quotes") if has_insight else None,
                 "shares": insight.get("shares") if has_insight else None,
             }

--- a/tests/test_google_sheets.py
+++ b/tests/test_google_sheets.py
@@ -207,7 +207,7 @@ def test_write_posts_metrics_updates_existing_rows_and_formats(
                 "post_id": "123",
                 "permalink": "https://example.com/post",
                 "text": "new text",
-                "like_count": 5,
+                "like_count": 6,
                 "repost_count": 2,
                 "reply_count": 1,
                 "views": 15,
@@ -232,7 +232,12 @@ def test_write_posts_metrics_updates_existing_rows_and_formats(
     text_index = header.index("text")
     updated_at_index = header.index("updated_at")
 
-    assert row[like_index] == "5"
+    reply_index = header.index("reply_count")
+    repost_index = header.index("repost_count")
+
+    assert row[like_index] == "6"
+    assert row[reply_index] == "1"
+    assert row[repost_index] == "2"
     assert row[text_index] == "new text"
     assert row[updated_at_index] != "2024-01-01T00:00:00+03:00"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,9 @@ def test_aggregate_posts_merges_insights() -> None:
     assert first["likes"] == 15
     assert first["replies"] == 4
     assert first["reposts"] == 6
+    assert first["like_count"] == 15
+    assert first["reply_count"] == 4
+    assert first["repost_count"] == 6
     assert first["quotes"] == 2
     assert first["shares"] == 3
 
@@ -54,5 +57,8 @@ def test_aggregate_posts_merges_insights() -> None:
     assert second["likes"] == 5
     assert second["replies"] == 1
     assert second["reposts"] == 0
+    assert second["like_count"] == 5
+    assert second["reply_count"] == 1
+    assert second["repost_count"] == 0
     assert second["quotes"] is None
     assert second["shares"] is None


### PR DESCRIPTION
## Цель
* Обеспечить совпадение счётчиков поста с метриками Insights при их наличии и обновить связанные проверки.

## Влияние на производительность и сеть
* Без изменений: дополнительная логика не добавляет сетевых вызовов и не влияет на сложность.

## Затронутые модули
* `src/threads_metrics/aggregation.py`
* `tests/test_main.py`
* `tests/test_google_sheets.py`

## Обработка ошибок и ретраи
* Логика ретраев и обработки ошибок не изменялась и не требовалась.


------
https://chatgpt.com/codex/tasks/task_e_68d630993664832da56f74ca2cdc6445