### PR TITLE
fix: поддержать override URL для загрузки постов

### DIFF
--- a/src/threads_metrics/config.py
+++ b/src/threads_metrics/config.py
@@ -21,6 +21,7 @@ class Config:
         gas_deployment_url: URL развёрнутого Google Apps Script.
         service_account_info: Данные сервисного аккаунта Google.
         threads_api_base_url: Базовый URL API Threads.
+        threads_posts_url_override: Переопределение URL получения постов.
         request_timeout: Таймаут HTTP-запросов.
         concurrency_limit: Ограничение параллелизма для запросов.
         state_file: Путь к файлу состояния.
@@ -32,6 +33,7 @@ class Config:
     gas_deployment_url: str
     service_account_info: Dict[str, Any]
     threads_api_base_url: str
+    threads_posts_url_override: Optional[str]
     request_timeout: float
     concurrency_limit: int
     state_file: Path
@@ -64,6 +66,11 @@ class Config:
             raise ConfigError("Невозможно разобрать JSON сервисного аккаунта") from exc
 
         threads_api_base_url = env_map.get("THREADS_API_BASE_URL", "https://graph.threads.net")
+        threads_posts_url_override = env_map.get(
+            "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_and_PERMALINK_only"
+        )
+        if threads_posts_url_override:
+            threads_posts_url_override = threads_posts_url_override.strip() or None
         request_timeout = cls._parse_float(env_map.get("THREADS_REQUEST_TIMEOUT", "30"),
                                            "THREADS_REQUEST_TIMEOUT")
         concurrency_limit = cls._parse_int(env_map.get("THREADS_CONCURRENCY", "5"),
@@ -81,6 +88,7 @@ class Config:
             gas_deployment_url=gas_deployment_url,
             service_account_info=service_account_info,
             threads_api_base_url=threads_api_base_url.rstrip("/"),
+            threads_posts_url_override=threads_posts_url_override,
             request_timeout=request_timeout,
             concurrency_limit=concurrency_limit,
             state_file=state_file,

--- a/src/threads_metrics/main.py
+++ b/src/threads_metrics/main.py
@@ -58,6 +58,7 @@ async def app_dependencies(config: Config) -> Any:
         base_url=config.threads_api_base_url,
         timeout=config.request_timeout,
         concurrency_limit=config.concurrency_limit,
+        posts_url_override=config.threads_posts_url_override,
     )
     sheets = GoogleSheetsClient(
         table_id=config.google_table_id,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,11 +12,19 @@ def test_config_from_env_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ID_GOOGLE_TABLE", "table")
     monkeypatch.setenv("URL_GAS_RAZVERTIVANIA", "https://example.com")
     monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_JSON", "{}")
+    monkeypatch.setenv(
+        "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_and_PERMALINK_only",
+        " https://graph.threads.net/v1.0/me/threads?fields=id,permalink ",
+    )
 
     config = Config.from_env()
 
     assert config.google_table_id == "table"
     assert config.threads_api_base_url == "https://graph.threads.net"
+    assert (
+        config.threads_posts_url_override
+        == "https://graph.threads.net/v1.0/me/threads?fields=id,permalink"
+    )
     assert config.run_timeout_minutes == 100
 
 

--- a/tests/test_threads_client.py
+++ b/tests/test_threads_client.py
@@ -1,3 +1,5 @@
+import asyncio
+import httpx
 import pytest
 
 from src.threads_metrics.threads_client import ThreadsClient
@@ -26,3 +28,31 @@ from src.threads_metrics.threads_client import ThreadsClient
 )
 def test_sanitize_permalink(permalink: str, expected: str) -> None:
     assert ThreadsClient._sanitize_permalink(permalink) == expected
+
+
+def test_fetch_posts_uses_override_fields() -> None:
+    captured_url = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured_url["value"] = str(request.url)
+        return httpx.Response(200, json={"data": [], "paging": {}})
+
+    async def runner() -> None:
+        transport = httpx.MockTransport(handler)
+        client = ThreadsClient(
+            base_url="https://graph.threads.net",
+            timeout=10,
+            transport=transport,
+            posts_url_override="https://graph.threads.net/v1.0/me/threads?fields=id,permalink",
+        )
+
+        try:
+            await client.fetch_posts("token")
+        finally:
+            await client.close()
+
+    asyncio.run(runner())
+
+    assert "value" in captured_url
+    assert "fields=id%2Cpermalink" in captured_url["value"]
+    assert "text" not in captured_url["value"]


### PR DESCRIPTION
## Summary
- добавить чтение URL для получения постов из секрета окружения и прокинуть его в инициализацию ThreadsClient
- обновить ThreadsClient так, чтобы он использовал переопределённый путь и параметры без потери пагинации и очистки курсора
- дополнить модульные тесты конфигурации и клиента проверками новой логики

## Impact
- Количество HTTP-запросов и таймауты не изменились; меняется только набор передаваемых полей в существующих запросах.
- Механизм ретраев остаётся прежним: tenacity с экспоненциальным бэкоффом.

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d641d01598832d9cddc98c89f4622c