### PR TITLE
fix: обновить имя переменной окружения Threads

### DIFF
--- a/src/threads_metrics/config.py
+++ b/src/threads_metrics/config.py
@@ -67,8 +67,12 @@ class Config:
 
         threads_api_base_url = env_map.get("THREADS_API_BASE_URL", "https://graph.threads.net")
         threads_posts_url_override = env_map.get(
-            "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_and_PERMALINK_only"
+            "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_AND_PERMALINK_ONLY"
         )
+        if threads_posts_url_override is None:
+            threads_posts_url_override = env_map.get(
+                "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_and_PERMALINK_only"
+            )
         if threads_posts_url_override:
             threads_posts_url_override = threads_posts_url_override.strip() or None
         request_timeout = cls._parse_float(env_map.get("THREADS_REQUEST_TIMEOUT", "30"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ def test_config_from_env_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("URL_GAS_RAZVERTIVANIA", "https://example.com")
     monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_JSON", "{}")
     monkeypatch.setenv(
-        "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_and_PERMALINK_only",
+        "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_AND_PERMALINK_ONLY",
         " https://graph.threads.net/v1.0/me/threads?fields=id,permalink ",
     )
 
@@ -26,6 +26,25 @@ def test_config_from_env_success(monkeypatch: pytest.MonkeyPatch) -> None:
         == "https://graph.threads.net/v1.0/me/threads?fields=id,permalink"
     )
     assert config.run_timeout_minutes == 100
+
+
+def test_config_supports_legacy_threads_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Проверяет обратную совместимость со старым именем переменной."""
+
+    monkeypatch.setenv("ID_GOOGLE_TABLE", "table")
+    monkeypatch.setenv("URL_GAS_RAZVERTIVANIA", "https://example.com")
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_JSON", "{}")
+    monkeypatch.setenv(
+        "URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_and_PERMALINK_only",
+        " https://graph.threads.net/v1.0/me/threads?fields=id,permalink ",
+    )
+
+    config = Config.from_env()
+
+    assert (
+        config.threads_posts_url_override
+        == "https://graph.threads.net/v1.0/me/threads?fields=id,permalink"
+    )
 
 
 def test_config_respects_run_timeout(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Резюме
- обновил загрузку конфигурации, добавив поддержку нового ключа `URL_THREADS_TAKE_ID_FROM_CURRENT_ACCOUNT_ID_AND_PERMALINK_ONLY` с запасной проверкой старого имени
- скорректировал модульные тесты и добавил проверку обратной совместимости

## Влияние на производительность и сеть
- изменений в количестве запросов и таймаутах нет

## Модули
- `threads_metrics.config`
- `tests.test_config`

## Обработка ошибок и ретраи
- логика валидации переменных окружения не менялась, новых ретраев не добавлено

------
https://chatgpt.com/codex/tasks/task_e_68d6476be5e8832d8885f79c30c5b7dd