### PR TITLE
fix: обработка ошибок Threads при сборе постов

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,18 @@
 """Тесты для функций основного модуля."""
 from __future__ import annotations
 
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import httpx
+import pytest
+
 from threads_metrics.aggregation import aggregate_posts
+from threads_metrics.google_sheets import AccountToken
+from threads_metrics.main import collect_posts
+from threads_metrics.threads_client import ThreadsFetchResult, ThreadsPost
 
 
 def test_aggregate_posts_merges_insights() -> None:
@@ -62,3 +73,72 @@ def test_aggregate_posts_merges_insights() -> None:
     assert second["repost_count"] == 0
     assert second["quotes"] is None
     assert second["shares"] is None
+
+
+@dataclass
+class _StubClient:
+    responses: Dict[str, object]
+    concurrency_limit: int = 2
+
+    async def fetch_posts(self, token: str, after: Optional[str] = None) -> ThreadsFetchResult:
+        result = self.responses[token]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class _StubSheets:
+    def __init__(self, cursors: Optional[Dict[str, Optional[str]]] = None) -> None:
+        self.cursors = cursors or {}
+
+    def get_last_processed_cursor(self, account_name: str) -> Optional[str]:
+        return self.cursors.get(account_name)
+
+    def set_last_processed_cursor(self, account_name: str, cursor: str) -> None:
+        self.cursors[account_name] = cursor
+
+
+def test_collect_posts_skips_accounts_on_http_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Проверяет обработку ошибок Threads API при сборе постов."""
+
+    tokens = [
+        AccountToken(account_name="error_account", token="token-error"),
+        AccountToken(account_name="ok_account", token="token-ok"),
+    ]
+
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(status_code=403, request=request)
+    error = httpx.HTTPStatusError("Forbidden", request=request, response=response)
+
+    successful_result = ThreadsFetchResult(
+        posts=[
+            ThreadsPost(
+                id="42",
+                permalink="https://threads.net/p/42",
+                data={"id": "42", "text": "hello"},
+            )
+        ],
+        next_cursor="next-cursor",
+    )
+
+    client = _StubClient(responses={"token-error": error, "token-ok": successful_result})
+    sheets = _StubSheets(cursors={"error_account": "prev-cursor"})
+
+    with caplog.at_level(logging.WARNING):
+        posts = asyncio.run(collect_posts(tokens, client, sheets))
+
+    assert posts == [
+        {
+            "id": "42",
+            "permalink": "https://threads.net/p/42",
+            "text": "hello",
+            "account_name": "ok_account",
+        }
+    ]
+
+    assert sheets.cursors["error_account"] == "prev-cursor"
+    assert sheets.cursors["ok_account"] == "next-cursor"
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert warnings, "Ожидалось предупреждение в логах"
+    assert any("Не удалось получить посты" in record.message for record in warnings)


### PR DESCRIPTION
## Цель
- предотвратить обрыв обновления метрик при ошибках Threads API и сохранить корректный курсор в Google Sheets

## Изменения
- добавлена обработка httpx.HTTPStatusError и ThreadsAPIError в сборщике постов с логированием предупреждений
- сохранение курсора Google Sheets выполняется только при успешном получении постов
- добавлен модульный тест, покрывающий сценарий ошибки 403 для одного аккаунта и успешного ответа для другого

## Влияние на производительность и сеть
- без изменений: количество запросов и ограничения параллелизма прежние

## Затронутые модули
- `src/threads_metrics/main.py`
- `tests/test_main.py`

## Обработка ошибок и ретраи
- ошибки Threads API перехватываются и фиксируются в логах; при этом остальные аккаунты обрабатываются без прерывания выполнения

## Тесты
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d6822e49ac832d8579f854c1a66f9c