### PR TITLE
fix: ограничить отмену запусков workflow threads-metrics

### DIFF
--- a/src/threads_metrics/gh_cancel.py
+++ b/src/threads_metrics/gh_cancel.py
@@ -31,8 +31,8 @@ async def _fetch_runs(
     """Получает список запусков workflow в заданном статусе."""
 
     response = await client.get(
-        f"/repos/{owner}/{repo}/actions/runs",
-        params={"workflow_id": WORKFLOW_FILE, "status": status},
+        f"/repos/{owner}/{repo}/actions/workflows/{WORKFLOW_FILE}/runs",
+        params={"status": status},
     )
     remaining = response.headers.get("X-RateLimit-Remaining")
     response.raise_for_status()


### PR DESCRIPTION
## Цель изменения
- запрашивать очереди GitHub Actions только для workflow `threads-metrics.yml` через специализированный endpoint
- убедиться, что отменяются лишь ожидания нужного workflow и обновить тесты

## Влияние на производительность и сеть
- используем более узкий endpoint `/actions/workflows/{file}/runs`, что сокращает объём возвращаемых данных и не добавляет новых запросов

## Затронутые модули
- `src/threads_metrics/gh_cancel.py`
- `tests/test_gh_cancel.py`

## Ретраи и обработка ошибок
- существующая обработка `HTTPStatusError` сохранена без изменений; новых механизмов ретраев не добавлено

------
https://chatgpt.com/codex/tasks/task_e_68d6abb9d14c832db8edd96c6459c798