### PR TITLE
fix: расширить лист перед записью метрик

### DIFF
--- a/src/threads_metrics/google_sheets.py
+++ b/src/threads_metrics/google_sheets.py
@@ -196,6 +196,8 @@ class GoogleSheetsClient:
             if appended_rows:
                 start_row = len(existing_df.index) + 2
                 end_row = start_row + len(appended_rows) - 1
+                if end_row > sheet.row_count:
+                    sheet.add_rows(end_row - sheet.row_count)
                 start_cell = rowcol_to_a1(start_row, 1)
                 end_cell = rowcol_to_a1(end_row, len(columns))
                 batch_payload.append(


### PR DESCRIPTION
## Что сделано
- перед добавлением новых строк проверяю вместимость листа и при необходимости расширяю сетку

## Влияние на производительность и сеть
- дополнительный вызов `add_rows` выполняется только при нехватке строк, запросов больше не стало

## Модули
- `src/threads_metrics/google_sheets.py`

## Ретраи и обработка ошибок
- используется существующая обработка ошибок метода `write_posts_metrics`


------
https://chatgpt.com/codex/tasks/task_e_68d6cded7b08832da0d51f7591e965db