### PR TITLE
fix: исправить логирование ошибок форматирования Google Sheets

### DIFF
--- a/src/threads_metrics/google_sheets.py
+++ b/src/threads_metrics/google_sheets.py
@@ -353,7 +353,11 @@ class GoogleSheetsClient:
         except Exception:
             logging.exception(
                 "Не удалось применить форматирование листа Google Sheets",
-                extra={"context": json.dumps({"rows": rows, "columns": columns})},
+                extra={
+                    "context": json.dumps(
+                        {"rows": rows_count, "columns": columns}
+                    )
+                },
             )
 
     def get_last_processed_cursor(self, account_name: str) -> Optional[str]:


### PR DESCRIPTION
## Цель изменения
Исправить обращение к несуществующей переменной в логировании ошибок форматирования листа Google Sheets.

## Влияние на производительность и сеть
Не влияет.

## Модули
- `src/threads_metrics/google_sheets.py`

## Ретраи и обработка ошибок
Логирование ошибок форматирования теперь использует корректное имя переменной и больше не вызывает дополнительных исключений.

------
https://chatgpt.com/codex/tasks/task_e_68d6cdee544c832d9163b8157d08a83b