### PR TITLE
feat: самоотменять повторные запуски threads metrics

### DIFF
--- a/.github/workflows/threads-metrics.yml
+++ b/.github/workflows/threads-metrics.yml
@@ -8,8 +8,51 @@ on:
 concurrency:
   group: threads-metrics
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      should_continue: ${{ steps.check.outputs.should_continue }}
+    steps:
+      - name: Проверить активные запуски
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const response = await github.request(
+              'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'threads-metrics.yml',
+                status: 'in_progress',
+                per_page: 50,
+              }
+            );
+            const otherRuns = response.data.workflow_runs.filter(
+              (run) => run.id !== context.runId
+            );
+            const shouldContinue = otherRuns.length === 0;
+            core.setOutput('should_continue', shouldContinue ? 'true' : 'false');
+            if (!shouldContinue) {
+              core.notice(`Найдено ${otherRuns.length} активных запусков, отменяем текущий.`);
+              await github.request(
+                'POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: context.runId,
+                }
+              );
+            }
+
   run-metrics:
+    needs: guard
+    if: needs.guard.outputs.should_continue == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 100
     env:


### PR DESCRIPTION
## Goal
- Обеспечить самопрерывание workflow Threads Metrics при наличии другого активного запуска.

## Summary
- Добавлен guard-job с проверкой API Actions и отменой текущего run при обнаружении других in_progress запусков.
- Основной job Threads Metrics выполняется только при явном разрешении охранного шага.
- Выданы права `actions: write`, чтобы workflow мог отменить самого себя.

## Impact
- Небольшое увеличение времени старта за счёт дополнительного запроса к API GitHub Actions.
- Сетевой доступ ограничен одним GET и, при необходимости, одним POST-запросом к API GitHub.

## Modules
- `.github/workflows/threads-metrics.yml`

## Retry / Error handling
- Отмена запуска происходит сразу после обнаружения параллельных запусков через API GitHub.

## Testing
- not run (изменения в workflow)


------
https://chatgpt.com/codex/tasks/task_e_68d6eac3f370832d9a62b6f25dcbd890